### PR TITLE
Update docs, provide file as arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # script-speaker
+
+Reads a SpongeBob SquarePants eposide script on MacOS using voice accessibility options.
+
+## Installation
+
+* Install NodeJS.
+* Install the following `say` voices in MacOS voice assistance:
+ * `junior`
+ * `daniel`
+ * `tomas`
+ * `ralph`
+ * `bruce`
+ * `fred`
+ * `alex`
+
+## Usage
+
+Provide the script file to read as an argument.  For example:
+
+```bash
+node script-speaker.js hash-slinging-slasher.txt
+```

--- a/script-speaker.js
+++ b/script-speaker.js
@@ -1,8 +1,10 @@
 const { spawn, spawnSync } = require("child_process");
 const fs = require("fs");
 
+const file = process.argv[2];
+
 const script = fs
-  .readFileSync("./hash-slinging-slasher.txt")
+  .readFileSync(file)
   .toString("utf-8")
   .split("\n");
 

--- a/script-speaker.js
+++ b/script-speaker.js
@@ -30,7 +30,9 @@ script.forEach(line => {
     line = line.replace(results[0][0], "");
   }
 
-  if (names.length === 0) return;
+  if (names.length === 0) {
+    return;
+  };
 
   voices = names.map(name => {
     switch (name) {


### PR DESCRIPTION
Adds a brief README.

Allows the user to pass the script file as an argument.

Uses 1TBS.